### PR TITLE
Specified MIRSG instead of just the ARC centre

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,7 +219,7 @@
 											<tr>
 												<td>Deploying Cloud ML Models Using Microsoft InnerEye</td>
 												<td>Tom Dowrick, <a href="https://www.haroonrchughtai.com/">Haroon Chugthai</a></td>
-												<td><a href="http://compass.cs.ucl.ac.uk/">COMPASS, </a><a href="https://www.ucl.ac.uk/arc/">ARC</a></td>
+												<td><a href="http://compass.cs.ucl.ac.uk/">COMPASS, </a><a href="https://www.ucl.ac.uk/advanced-research-computing/expertise/research-software-development/medical-imaging-research-software-group">ARC/CMIC MIRSG</a></td>
 												<td><a href="https://github.com/microsoft/InnerEye-DeepLearning">Microsoft InnerEye</a> provides a suite of tools for training and developing medical imaging algorithms either using local computing resources or Azure cloud services, and there are many algorithms/models developed within CMIC that would benefit from compatiblity with InnerEye, to allow for more widespread deployment. 
 												<br /> During this hackathon project, participants will convert existing models developed within CMIC to use PyTorch Lightning, and then deploy them on the cloud using InnerEye. Pariticipants will also work to deploy a local InnerEye environment using existing CMIC computing resources, to provide a testing/development environment that can be used in the longer term, to prepare models before they are deployed on the cloud.</td>
 											</tr>


### PR DESCRIPTION
This PR updates my affiliation to explicitly specify the [ARC/CMIC Medical Imaging Research Software Group](https://www.ucl.ac.uk/advanced-research-computing/expertise/research-software-development/medical-imaging-research-software-group) which is run as a collaborative effort between CMIC and ARC. (ARC is both a department and a centre)

